### PR TITLE
TD-26: Agregar caso de prueba positivo del endpoint Update a personal label

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+.idea/
+report.html

--- a/src/assertions/labels/update_a_label_assertions.py
+++ b/src/assertions/labels/update_a_label_assertions.py
@@ -1,0 +1,11 @@
+from src.utils.json_reader import read_a_json
+from src.assertions.schema_assertion import assert_schema
+
+
+def assert_update_a_label_case_one(response, label_data):
+    schema = read_a_json("label_schema.json")
+    assert_schema(response, schema)
+    response_data = response.json()
+    assert response.status_code == 200
+    assert response.headers['Content-Type'] == 'application/json'
+    assert response_data["name"] == label_data["name"]

--- a/src/postman_requests/labels/update_a_label.py
+++ b/src/postman_requests/labels/update_a_label.py
@@ -1,0 +1,13 @@
+import requests
+
+url = "https://api.todoist.com/rest/v2/labels/2173033391"
+
+payload = "{\"name\": \"casual1\"}"
+headers = {
+    'Content-Type': 'application/json',
+    'Authorization': 'Bearer ec89cb82258d5f39de31b4850fa1505b214e2581',
+}
+
+response = requests.request("POST", url, headers=headers, data=payload)
+
+print(response.text)

--- a/src/resources/payloads/update_label_data.py
+++ b/src/resources/payloads/update_label_data.py
@@ -1,0 +1,2 @@
+label_id = "2173805399"
+label_data = {"name": "important"}

--- a/src/resources/schemas/label_schema.json
+++ b/src/resources/schemas/label_schema.json
@@ -1,0 +1,27 @@
+{
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string"
+        },
+        "name": {
+            "type": "string"
+        },
+        "order": {
+            "type": "integer"
+        },
+        "color": {
+            "type": "string"
+        },
+        "is_favorite": {
+            "type": "boolean"
+        }
+    },
+    "required": [
+        "id",
+        "name",
+        "order",
+        "color",
+        "is_favorite"
+    ]
+}

--- a/src/utils/label.py
+++ b/src/utils/label.py
@@ -7,3 +7,12 @@ def get_all_labels(token):
         'Authorization': f'Bearer {token}',
     }
     return requests.get(url, headers=headers)
+
+
+def update_a_label(label_id, label_data, token):
+    url = f"https://api.todoist.com/rest/v2/labels/{label_id}"
+    headers = {
+        'Content-Type': 'application/json',
+        'Authorization': f'Bearer {token}',
+    }
+    return requests.post(url, headers=headers, data=label_data)

--- a/tests/labels/test_get_all_labels.py
+++ b/tests/labels/test_get_all_labels.py
@@ -1,5 +1,3 @@
-import pytest
-import jsonschema
 from src.login import get_token
 from src.utils.label import get_all_labels
 from src.assertions.labels.get_all_labels_assertions import assert_get_all_labels_case_one

--- a/tests/labels/test_update_a_label.py
+++ b/tests/labels/test_update_a_label.py
@@ -1,0 +1,11 @@
+import json
+from src.login import get_token
+from src.utils.label import update_a_label
+from src.resources.payloads.update_label_data import label_id, label_data
+from src.assertions.labels.update_a_label_assertions import assert_update_a_label_case_one
+
+
+def test_update_a_label():
+    response = update_a_label(label_id, json.dumps(label_data), get_token())
+    assert_update_a_label_case_one(response, label_data)
+


### PR DESCRIPTION
* Agregar caso de prueba positivo del endpoint Update a personal label
![image](https://github.com/G1-ModuloV/apitest-todoist/assets/173567764/6ebe5a2d-916e-4f86-b4db-e33e17dc26eb)
