### PR TITLE
TD-45: Agregar los casos de prueba smoke del endpoint delete a personal label

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -28,7 +28,7 @@ def alphanumeric_project_id():
     return "abc123xyz"
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def valid_token():
     return get_token()
 

--- a/src/assertions/labels/delete_a_label_assertions.py
+++ b/src/assertions/labels/delete_a_label_assertions.py
@@ -1,0 +1,10 @@
+def assert_delete_a_label_successfully(response):
+    assert response.status_code == 204
+    assert response.headers['Content-Type'] == 'text/html; charset=utf-8'
+    assert response.content == b''
+
+
+def assert_delete_a_label_forbidden(response):
+    assert response.status_code == 401
+    assert response.headers['Content-Type'] == 'text/plain; charset=utf-8'
+    assert response.content == b'Forbidden'

--- a/src/utils/label.py
+++ b/src/utils/label.py
@@ -25,3 +25,11 @@ def update_a_label(label_id, label_data, token):
         'Authorization': f'Bearer {token}',
     }
     return requests.post(url, headers=headers, data=label_data)
+
+
+def delete_a_label(label_id, token):
+    url = f'{BASE_URI}/rest/v2/labels/{label_id}'
+    headers = {
+        'Authorization': f'Bearer {token}',
+    }
+    return requests.delete(url, headers=headers)

--- a/tests/labels/conftest.py
+++ b/tests/labels/conftest.py
@@ -1,0 +1,27 @@
+import pytest
+import requests
+import json
+from config import BASE_URI
+from src.utils.label import delete_a_label
+
+
+@pytest.fixture(scope="session")
+def get_valid_label_id(valid_token):
+    url = f"{BASE_URI}/rest/v2/labels"
+    headers = {
+        'Authorization': f'Bearer {valid_token}',
+        'Content-Type': 'application/json',
+    }
+    payload = {
+        "name": "Food"
+    }
+    response = requests.post(url, headers=headers, data=json.dumps(payload))
+    response_data = response.json()
+    label_id = response_data["id"]
+
+    def teardown():
+        delete_a_label(label_id, valid_token)
+
+    yield label_id
+    teardown()
+    return label_id

--- a/tests/labels/conftest.py
+++ b/tests/labels/conftest.py
@@ -25,3 +25,8 @@ def get_valid_label_id(valid_token):
     yield label_id
     teardown()
     return label_id
+
+
+@pytest.fixture
+def nonexistent_label_id():
+    return "2173775788"

--- a/tests/labels/test_delete_a_label.py
+++ b/tests/labels/test_delete_a_label.py
@@ -1,0 +1,20 @@
+import pytest
+from src.utils.label import delete_a_label
+from src.assertions.labels.delete_a_label_assertions import assert_delete_a_label_successfully, \
+    assert_delete_a_label_forbidden
+
+
+@pytest.mark.smoke
+@pytest.mark.regression
+# 1 Verificar la eliminacion de una etiqueta con un id valido y un token de autenticación valido
+def test_delete_a_label_valid_case(get_valid_label_id, valid_token):
+    response = delete_a_label(get_valid_label_id, valid_token)
+    assert_delete_a_label_successfully(response)
+
+
+@pytest.mark.smoke
+@pytest.mark.regression
+# 2 Verificar la eliminacion de una etiqueta con un id invalido y un token de autenticación invalido
+def test_delete_a_label_invalid_case(deleted_label_id, invalid_token):
+    response = delete_a_label(deleted_label_id, invalid_token)
+    assert_delete_a_label_forbidden(response)

--- a/tests/labels/test_delete_a_label.py
+++ b/tests/labels/test_delete_a_label.py
@@ -6,7 +6,7 @@ from src.assertions.labels.delete_a_label_assertions import assert_delete_a_labe
 
 @pytest.mark.smoke
 @pytest.mark.regression
-# 1 Verificar la eliminacion de una etiqueta con un id valido y un token de autenticación valido
+# TD-45 Verificar la eliminacion de una etiqueta con un id valido y un token de autenticación valido
 def test_delete_a_label_valid_case(get_valid_label_id, valid_token):
     response = delete_a_label(get_valid_label_id, valid_token)
     assert_delete_a_label_successfully(response)
@@ -14,7 +14,7 @@ def test_delete_a_label_valid_case(get_valid_label_id, valid_token):
 
 @pytest.mark.smoke
 @pytest.mark.regression
-# 2 Verificar la eliminacion de una etiqueta con un id invalido y un token de autenticación invalido
-def test_delete_a_label_invalid_case(deleted_label_id, invalid_token):
-    response = delete_a_label(deleted_label_id, invalid_token)
+# TD-45 Verificar la eliminacion de una etiqueta con un id invalido y un token de autenticación invalido
+def test_delete_a_label_invalid_case(nonexistent_label_id, invalid_token):
+    response = delete_a_label(nonexistent_label_id, invalid_token)
     assert_delete_a_label_forbidden(response)


### PR DESCRIPTION
* Agregar los casos de prueba smoke del endpoint delete a personal label.
![image](https://github.com/G1-ModuloV/apitest-todoist/assets/173567764/15e81317-d156-4c80-b962-186121b8ff36)
