### PR TITLE
TD-50: Agregar casos de prueba para el endpoint rename shared labels

### DIFF
--- a/src/assertions/labels/rename_shared_labels_assertions.py
+++ b/src/assertions/labels/rename_shared_labels_assertions.py
@@ -1,0 +1,24 @@
+def assert_rename_share_labels_forbidden(response):
+    assert_empty_body(response, 401, "text/plain; charset=utf-8", b'Forbidden')
+
+
+def assert_rename_share_labels_new_name_required(response):
+    assert_empty_body(response, 400, "text/plain; charset=utf-8", b'new_name required')
+
+
+def assert_rename_share_labels_successfully(response):
+    assert_empty_body(response, 204, 'text/html; charset=utf-8')
+
+
+def assert_a_share_label_exists(label, share_labels):
+    assert str(label) in share_labels
+
+
+def assert_there_is_no_a_share_label(label, share_labels):
+    assert str(label) not in share_labels
+
+
+def assert_empty_body(response, status_code, content_type, content=b''):
+    assert response.status_code == status_code
+    assert response.headers['Content-Type'] == content_type
+    assert response.content == content

--- a/src/resources/payloads/rename_share_labels_data.py
+++ b/src/resources/payloads/rename_share_labels_data.py
@@ -1,0 +1,24 @@
+label_payload = {"name": "my label"}
+task_payload = {
+    "content": "my new task",
+}
+updated_task_payload = {
+        "labels": [label_payload["name"]],
+}
+payload_correct = {"name": "my label", "new_name": "renamed label"}
+payload_good_new_name = [
+    payload_correct,
+    {"name": "my label", "new_name": 1234},
+    {"name": "my label", "new_name": True}
+]
+payload_bad_name = [
+    {"name": "nonexistent", "new_name": "renamed label"},
+    {"name": 1234, "new_name": "renamed label"},
+    {"name": True, "new_name": "renamed label"},
+    {"new_name": "renamed label"}
+]
+payload_bad_new_name = [
+    {"name": "my label", "new_name": ""},
+    {"name": "my label"},
+    {}
+]

--- a/src/utils/label.py
+++ b/src/utils/label.py
@@ -42,3 +42,20 @@ def create_a_personal_label(label_data, token):
         'Authorization': f'Bearer {token}',
     }
     return requests.post(url, headers=headers, data=label_data)
+
+
+def get_all_shared_labels(token, auth_type="Bearer"):
+    url = f"{BASE_URI}/rest/v2/labels/shared"
+    headers = {
+        'Authorization': f'{auth_type} {token}',
+    }
+    return requests.get(url, headers=headers)
+
+
+def rename_share_labels(label_data, token, content_type="application/json"):
+    url = f"{BASE_URI}/rest/v2/labels/shared/rename"
+    headers = {
+        'Content-Type': content_type,
+        'Authorization': f'Bearer {token}',
+    }
+    return requests.post(url, headers=headers, data=label_data)

--- a/tests/labels/conftest.py
+++ b/tests/labels/conftest.py
@@ -1,21 +1,14 @@
 import pytest
-import requests
 import json
-from config import BASE_URI
-from src.utils.label import delete_a_label
+from src.utils.label import delete_a_label, create_a_personal_label
+from src.utils.task import create_task, delete_task, update_a_task
+from src.resources.payloads.rename_share_labels_data import label_payload, updated_task_payload, task_payload
 
 
 @pytest.fixture(scope="session")
 def get_valid_label_id(valid_token):
-    url = f"{BASE_URI}/rest/v2/labels"
-    headers = {
-        'Authorization': f'Bearer {valid_token}',
-        'Content-Type': 'application/json',
-    }
-    payload = {
-        "name": "Food"
-    }
-    response = requests.post(url, headers=headers, data=json.dumps(payload))
+    payload = {"name": "Food"}
+    response = create_a_personal_label(json.dumps(payload), valid_token)
     response_data = response.json()
     label_id = response_data["id"]
 
@@ -30,3 +23,32 @@ def get_valid_label_id(valid_token):
 @pytest.fixture
 def nonexistent_label_id():
     return "2173775788"
+
+
+@pytest.fixture(scope="session")
+def get_task_id(valid_token):
+    response = create_task(task_payload, valid_token)
+    response_data = response.json()
+    task_id = response_data["id"]
+
+    def teardown():
+        delete_task(task_id, valid_token)
+
+    yield task_id
+    teardown()
+    return task_id
+
+
+@pytest.fixture(scope="function")
+def get_shared_label_id(valid_token, get_task_id):
+    response = create_a_personal_label(json.dumps(label_payload), valid_token)
+    response_data = response.json()
+    label_id = response_data["id"]
+    update_a_task(get_task_id, json.dumps(updated_task_payload), valid_token)
+
+    def teardown():
+        delete_a_label(label_id, valid_token)
+
+    yield label_id
+    teardown()
+    return label_id

--- a/tests/labels/test_rename_shared_labels.py
+++ b/tests/labels/test_rename_shared_labels.py
@@ -1,0 +1,65 @@
+import json
+import pytest
+from src.utils.label import rename_share_labels, get_all_shared_labels
+from src.resources.payloads.rename_share_labels_data import payload_correct, payload_bad_name, payload_bad_new_name, \
+    payload_good_new_name
+from src.assertions.labels.rename_shared_labels_assertions import assert_rename_share_labels_successfully, \
+    assert_rename_share_labels_forbidden, assert_rename_share_labels_new_name_required, assert_a_share_label_exists, \
+    assert_there_is_no_a_share_label
+
+
+@pytest.mark.smoke
+@pytest.mark.regression
+@pytest.mark.parametrize("payload", payload_good_new_name)
+# TD-50 Verificar el cambio de nombre de una etiqueta compartida a partir de name y new_name validos, usando content-type correcto y un token valido.
+# TD-50 Verificar el cambio de nombre de una etiqueta compartida a partir de name y new_name numerico, usando content-type correcto y un token valido.
+# TD-50 Verificar el cambio de nombre de una etiqueta compartida a partir de name y new_name booleano, usando content-type correcto y un token valido.
+def test_rename_shared_labels_good_new_name(payload, valid_token, get_shared_label_id):
+    response = rename_share_labels(json.dumps(payload), valid_token)
+    assert_rename_share_labels_successfully(response)
+    share_labels = get_all_shared_labels(valid_token).json()
+    assert_a_share_label_exists(payload["new_name"], share_labels)
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize("payload", payload_bad_name)
+# TD-50 Verificar el cambio de nombre de una etiqueta compartida a partir de name inexistente, new_name valido, usando content-type correcto y un token valido.
+# TD-50 Verificar el cambio de nombre de una etiqueta compartida a partir de name numerico, new_name valido, usando content-type correcto y un token valido.
+# TD-50 Verificar el cambio de nombre de una etiqueta compartida a partir de name booleano, new_name valido, usando content-type correcto y un token valido.
+# TD-50 Verificar el cambio de nombre de una etiqueta compartida a partir de new_name valido, sin name, usando content-type correcto y un token valido.
+def test_rename_shared_labels_bad_name(payload, valid_token):
+    response = rename_share_labels(json.dumps(payload), valid_token)
+    assert_rename_share_labels_successfully(response)
+    share_labels = get_all_shared_labels(valid_token).json()
+    assert_there_is_no_a_share_label(payload["new_name"], share_labels)
+
+
+@pytest.mark.regression
+@pytest.mark.parametrize("payload", payload_bad_new_name)
+# TD-50 Verificar el cambio de nombre de una etiqueta compartida a partir de name valido, new_name vacio, usando content-type correcto y un token valido.
+# TD-50 Verificar el cambio de nombre de una etiqueta compartida a partir de name valido, sin new_name, usando content-type correcto y un token valido.
+# TD-50 Verificar el cambio de nombre de una etiqueta compartida a partir de un payload vacio, usando content-type correcto y un token valido.
+def test_rename_shared_labels_bad_new_name(payload, valid_token):
+    response = rename_share_labels(json.dumps(payload), valid_token)
+    assert_rename_share_labels_new_name_required(response)
+
+
+@pytest.mark.regression
+# TD-50 Verificar el cambio de nombre de una etiqueta compartida a partir de name y new_name validos, usando content-type incorrecto y un token valido.
+def test_rename_shared_labels_bad_content_type(valid_token):
+    response = rename_share_labels(json.dumps(payload_correct), valid_token, "text/plain")
+    assert_rename_share_labels_new_name_required(response)
+
+
+@pytest.mark.regression
+# TD-50 Verificar el cambio de nombre de una etiqueta compartida a partir de name y new_name validos, usando content-type incorrecto y un token invalido.
+def test_rename_shared_labels_bad_content_type_bad_token(invalid_token):
+    response = rename_share_labels(json.dumps(payload_correct), invalid_token, "text/plain")
+    assert_rename_share_labels_forbidden(response)
+
+
+@pytest.mark.regression
+# TD-50 Verificar el cambio de nombre de una etiqueta compartida a partir de name y new_name validos, usando content-type correcto y un token invalido.
+def test_rename_shared_labels_bad_token(invalid_token):
+    response = rename_share_labels(json.dumps(payload_correct), invalid_token)
+    assert_rename_share_labels_forbidden(response)


### PR DESCRIPTION
* Agregar casos de prueba para el endpoint rename shared labels
![image](https://github.com/G1-ModuloV/apitest-todoist/assets/173567764/3a6581ff-bc04-4fec-98c4-a5a323ede9d3)
