### PR TITLE
TD-45: Agregar casos de prueba de tipo regresión para el endpoint delete a label

### DIFF
--- a/src/utils/url.py
+++ b/src/utils/url.py
@@ -1,0 +1,5 @@
+from config import BASE_URI
+
+
+def label_url(label_id):
+    return f"{BASE_URI}/rest/v2/labels/{label_id}"

--- a/tests/labels/test_delete_a_personal_label.py
+++ b/tests/labels/test_delete_a_personal_label.py
@@ -2,6 +2,8 @@ import pytest
 from src.utils.label import delete_a_label
 from src.assertions.labels.delete_a_label_assertions import assert_delete_a_label_successfully, \
     assert_delete_a_label_forbidden
+from config import BASE_URI
+import requests
 
 
 @pytest.mark.smoke
@@ -17,4 +19,25 @@ def test_delete_a_label_valid_case(get_valid_label_id, valid_token):
 # TD-45 Verificar la eliminación de una etiqueta con un id invalido y un token de autenticación invalido
 def test_delete_a_label_invalid_case(nonexistent_label_id, invalid_token):
     response = delete_a_label(nonexistent_label_id, invalid_token)
+    assert_delete_a_label_forbidden(response)
+
+
+@pytest.mark.regression
+# TD-45 Verificar la eliminación de una etiqueta con un id valido y un token de autenticación invalido
+def test_delete_a_label_bad_token(get_valid_label_id, invalid_token):
+    response = delete_a_label(get_valid_label_id, invalid_token)
+    assert_delete_a_label_forbidden(response)
+
+
+@pytest.mark.regression
+# TD-45 Verificar la eliminación de una etiqueta con un id invalido y un token de autenticación valido
+def test_delete_a_label_bad_id(nonexistent_label_id, valid_token):
+    response = delete_a_label(nonexistent_label_id, valid_token)
+    assert_delete_a_label_successfully(response)
+
+
+@pytest.mark.regression
+# TD-45 Verificar la eliminación de una etiqueta con un id valido y ningun tipo de autenticación
+def test_delete_a_label_without_authorization(get_valid_label_id):
+    response = requests.delete(f"{BASE_URI}/rest/v2/labels/{get_valid_label_id}", headers={})
     assert_delete_a_label_forbidden(response)

--- a/tests/labels/test_delete_a_personal_label.py
+++ b/tests/labels/test_delete_a_personal_label.py
@@ -2,8 +2,9 @@ import pytest
 from src.utils.label import delete_a_label
 from src.assertions.labels.delete_a_label_assertions import assert_delete_a_label_successfully, \
     assert_delete_a_label_forbidden
-from config import BASE_URI
 import requests
+
+from src.utils.url import label_url
 
 
 @pytest.mark.smoke
@@ -39,5 +40,5 @@ def test_delete_a_label_bad_id(nonexistent_label_id, valid_token):
 @pytest.mark.regression
 # TD-45 Verificar la eliminación de una etiqueta con un id valido y ningun tipo de autenticación
 def test_delete_a_label_without_authorization(get_valid_label_id):
-    response = requests.delete(f"{BASE_URI}/rest/v2/labels/{get_valid_label_id}", headers={})
+    response = requests.delete(label_url(get_valid_label_id), headers={})
     assert_delete_a_label_forbidden(response)


### PR DESCRIPTION
* Agregar casos de prueba de tipo regresión para el endpoint delete a label
![image](https://github.com/G1-ModuloV/apitest-todoist/assets/173567764/33fe5243-72b6-4d6b-8653-ff34449ed1ff)
